### PR TITLE
Add AzureTableCacheClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,15 @@ You can now use an Azure Blob Storage Container to serve website content with th
 
 ## Caching support with Azure Table Storage
 
-The Azure Table Cache Client implements ICacheClient 
+The AzureTableCacheClient implements [ICacheClientExteded](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.Interfaces/Caching/ICacheClientExtended.cs) and  
+[IRemoveByPattern](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.Interfaces/Caching/IRemoveByPattern.cs) using Azure Table Storage.  This provider 
+is currently implemented as "last writer wins", so concurrent writes to a single cache entry are discouraged.
+
+    public class AppHost : AppHostBase
+    {
+        public override void Configure(Container container)
+        {
+            string cacheConnStr = "UseDevelopmentStorage=true;";
+            container.Register<ICacheClient>(new AzureTableCacheClient(cacheConnStr));
+        }
+    }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,30 @@
-# ServiceStack.Azure
-ServiceStack adapters and bindings for Azure backend services
+## ServiceStack.Azure
+
+ServiceStack adapters and bindings for Azure backend services.
+
+## Drop-in Virtual FileSystem backed by Azure Blob Storage
+
+You can now use an Azure Blob Storage Container to serve website content with the drop-in **AzureBlobVirtualPathProvider**.
+
+    public class AppHost : AppHostBase
+    {
+        public override void Configure(Container container)
+        {
+            //All Razor Views, Markdown Content, imgs, js, css, etc are served from an Azure Blob Storage container
+            CloudStorageAccount storageAccount = CloudStorageAccount.DevelopmentStorageAccount;
+            VirtualFiles = new AzureBlobVirtualPathProvider(storageAccount, "websitecontent", this);
+        }
+
+        public override List<IVirtualPathProvider> GetVirtualFileSources()
+        {
+            //Add Azure Blob Container as lowest priority Virtual Path Provider 
+            var pathProviders = base.GetVirtualFileSources();
+            pathProviders.Add(VirtualFiles);
+            return pathProviders;
+        }
+    }
+
+
+## Caching support with Azure Table Storage
+
+The Azure Table Cache Client implements ICacheClient 

--- a/src/ServiceStack.Azure.Storage/AzureTableCacheClient.cs
+++ b/src/ServiceStack.Azure.Storage/AzureTableCacheClient.cs
@@ -1,0 +1,353 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using ServiceStack.Caching;
+using ServiceStack.Logging;
+using Microsoft.WindowsAzure.Storage;
+using ServiceStack.Support;
+using ServiceStack.Text;
+using Microsoft.WindowsAzure.Storage.Table;
+using ServiceStack.DataAnnotations;
+using System.Net;
+using System.Text.RegularExpressions;
+
+namespace ServiceStack.Azure.Storage
+{
+    public class AzureTableCacheClient : AdapterBase, ICacheClientExtended, IRemoveByPattern
+    {
+        TableCacheEntry CreateTableEntry(string rowKey, string data = null,
+            DateTime? created = null, DateTime? expires = null)
+        {
+            var createdDate = created ?? DateTime.UtcNow;
+            return new TableCacheEntry(rowKey)
+            {
+                Data = data,
+                ExpiryDate = expires,
+                CreatedDate = createdDate,
+                ModifiedDate = createdDate,
+            };
+        }
+
+
+        protected override ILog Log { get { return LogManager.GetLogger(GetType()); } }
+        public bool FlushOnDispose { get; set; }
+
+        string connectionString;
+        string partitionKey = "";
+        CloudTable table = null;
+        IStringSerializer serializer;
+
+        public AzureTableCacheClient(string ConnectionString, string tableName = "Cache")
+        {
+            connectionString = ConnectionString;
+            CloudStorageAccount storageAccount = CloudStorageAccount.Parse(connectionString);
+            CloudTableClient tableClient = storageAccount.CreateCloudTableClient();
+            table = tableClient.GetTableReference(tableName);
+            table.CreateIfNotExists();
+
+            serializer = new JsonStringSerializer();
+        }
+
+
+        private bool TryGetValue(string key, out TableCacheEntry entry)
+        {
+            entry = null;
+
+            TableOperation op = TableOperation.Retrieve<TableCacheEntry>(partitionKey, key);
+            TableResult retrievedResult = table.Execute(op);
+
+            if (retrievedResult.Result != null)
+            {
+                entry = retrievedResult.Result as TableCacheEntry;
+                return true;
+            }
+            else
+                return false;
+        }
+
+
+        public void Dispose()
+        {
+            if (!FlushOnDispose) return;
+
+            FlushAll();
+        }
+
+
+        public bool Add<T>(string key, T value)
+        {
+            string sVal = serializer.SerializeToString<T>(value);
+
+            TableCacheEntry entry = CreateTableEntry(key, sVal, null);
+            return AddInternal(key, entry);
+        }
+
+        public bool Add<T>(string key, T value, TimeSpan expiresIn)
+        {
+            return Add<T>(key, value, DateTime.UtcNow.Add(expiresIn));
+        }
+
+        public bool Add<T>(string key, T value, DateTime expiresAt)
+        {
+            string sVal = serializer.SerializeToString<T>(value);
+
+            TableCacheEntry entry = CreateTableEntry(key, sVal, null, expiresAt);
+            return AddInternal(key, entry);
+        }
+
+        public bool AddInternal(string key, TableCacheEntry entry)
+        {
+            TableOperation op = TableOperation.Insert(entry);
+            TableResult result = table.Execute(op);
+            return result.HttpStatusCode == 200;
+        }
+
+        public long Decrement(string key, uint amount)
+        {
+            return AtomicIncDec(key, amount * -1);
+        }
+
+        internal long AtomicIncDec(string key, long amount)
+        {
+            var entry = GetEntry(key) ?? CreateTableEntry(key, Serialize<long>(0));
+            long count = Deserialize<long>(entry.Data) + amount;
+            entry.Data = Serialize<long>(count);
+
+            SetInternal(key, entry);
+            return count;
+        }
+
+        public void FlushAll()
+        {
+            GetKeysByPattern("*").Each(q => Remove(q));
+        }
+
+        public T Get<T>(string key)
+        {
+            TableCacheEntry entry = GetEntry(key);
+            if (entry != null)
+                return Deserialize<T>(entry.Data);
+            return default(T);
+        }
+
+        internal TableCacheEntry GetEntry(string key)
+        {
+            TableCacheEntry entry = null;
+            if (TryGetValue(key, out entry))
+            {
+                if (entry.HasExpired)
+                {
+                    this.Remove(key);
+                    return null;
+                }
+                return entry;
+            }
+            return null;
+        }
+
+        public IDictionary<string, T> GetAll<T>(IEnumerable<string> keys)
+        {
+            var valueMap = new Dictionary<string, T>();
+            foreach (var key in keys)
+            {
+                var value = Get<T>(key);
+                valueMap[key] = value;
+            }
+            return valueMap;
+        }
+
+        public long Increment(string key, uint amount)
+        {
+            return AtomicIncDec(key, amount);
+        }
+
+        public bool Remove(string key)
+        {
+            TableCacheEntry entry = CreateTableEntry(key);
+            entry.ETag = "*";   // Avoids concurrency
+            TableOperation op = TableOperation.Delete(entry);
+            try
+            {
+                TableResult result = table.Execute(op);
+                return result.HttpStatusCode == 200 || result.HttpStatusCode == 204;
+            }
+            catch (Microsoft.WindowsAzure.Storage.StorageException ex)
+            {
+                if (ex.RequestInformation.HttpStatusCode == (int)System.Net.HttpStatusCode.NotFound)
+                    return false;
+                throw ex;
+            }
+        }
+
+        public void RemoveAll(IEnumerable<string> keys)
+        {
+            keys.Each(q => Remove(q));
+        }
+
+        public bool Replace<T>(string key, T value)
+        {
+            return Replace(key, value);
+        }
+
+        public bool Replace<T>(string key, T value, TimeSpan expiresIn)
+        {
+            string sVal = Serialize<T>(value);
+            return ReplaceInternal(key, sVal, DateTime.UtcNow.Add(expiresIn));
+        }
+
+        public bool Replace<T>(string key, T value, DateTime expiresAt)
+        {
+            string sVal = Serialize<T>(value);
+            return ReplaceInternal(key, sVal, expiresAt);
+        }
+
+        internal bool ReplaceInternal(string key, string value, DateTime? expiresAt = null)
+        {
+            TableCacheEntry entry = null;
+            if (TryGetValue(key, out entry))
+            {
+                entry = CreateTableEntry(key, value, null, expiresAt);
+                TableOperation op = TableOperation.Replace(entry);
+                TableResult result = table.Execute(op);
+                return result.HttpStatusCode == 200;
+            }
+            return false;
+        }
+
+        public bool Set<T>(string key, T value)
+        {
+            string sVal = Serialize<T>(value);
+            TableCacheEntry entry = CreateTableEntry(key, sVal);
+            return SetInternal(key, entry);
+        }
+
+        public bool Set<T>(string key, T value, TimeSpan expiresIn)
+        {
+            return Set(key, value, DateTime.UtcNow.Add(expiresIn));
+        }
+
+        public bool Set<T>(string key, T value, DateTime expiresAt)
+        {
+            string sVal = Serialize<T>(value);
+
+            TableCacheEntry entry = CreateTableEntry(key, sVal, null, expiresAt);
+            return SetInternal(key, entry);
+        }
+
+        internal bool SetInternal(string key, TableCacheEntry entry)
+        {
+            TableOperation op = TableOperation.InsertOrReplace(entry);
+            TableResult result = table.Execute(op);
+            return result.HttpStatusCode == 200 || result.HttpStatusCode == 204;    // Success or "No content"
+        }
+
+        public void SetAll<T>(IDictionary<string, T> values)
+        {
+            foreach (var key in values.Keys)
+            {
+                Set<T>(key, values[key]);
+            }
+        }
+
+        public TimeSpan? GetTimeToLive(string key)
+        {
+            TableCacheEntry entry = GetEntry(key);
+            if (entry != null)
+            {
+                if (entry.ExpiryDate == null)
+                    return TimeSpan.MaxValue;
+
+                return entry.ExpiryDate - DateTime.UtcNow;
+            }
+            return null;
+        }
+
+        public IEnumerable<string> GetKeysByPattern(string pattern)
+        {
+            // Very inefficient - query all keys and do client-side filter
+            TableQuery<TableCacheEntry> query = new TableQuery<TableCacheEntry>()
+                ;
+
+            return table.ExecuteQuery<TableCacheEntry>(query)
+                .Where(q => q.RowKey.Glob(pattern))
+                .Select(q => q.RowKey);
+        }
+
+        public IEnumerable<string> GetKeysByRegex(string regex)
+        {
+            // Very inefficient - query all keys and do client-side filter
+            TableQuery<TableCacheEntry> query = new TableQuery<TableCacheEntry>()
+                ;
+
+            Regex re = new Regex(regex, RegexOptions.Compiled | RegexOptions.Singleline);
+
+            return table.ExecuteQuery<TableCacheEntry>(query)
+                .Where(q => re.IsMatch(q.RowKey))
+                .Select(q => q.RowKey);
+        }
+
+        private string Serialize<T>(T value)
+        {
+            using (JsConfig.With(excludeTypeInfo: false))
+                return serializer.SerializeToString<T>(value);
+        }
+
+        private T Deserialize<T>(string text)
+        {
+            using (JsConfig.With(excludeTypeInfo: false))
+            {
+                return (text.IsNullOrEmpty()) ? default(T) :
+                    serializer.DeserializeFromString<T>(text);
+            }
+        }
+
+        public void RemoveByPattern(string pattern)
+        {
+            RemoveAll(GetKeysByPattern(pattern));
+        }
+
+        public void RemoveByRegex(string regex)
+        {
+            RemoveAll(GetKeysByRegex(regex));
+        }
+
+        public class TableCacheEntry : TableEntity
+        {
+
+            public TableCacheEntry(string key)
+            {
+                this.PartitionKey = "";
+                this.RowKey = key;
+            }
+
+            public TableCacheEntry() { }
+
+
+            [StringLength(1024 * 2014 /* 1 MB max */
+                - 1024 /* partition key max size*/
+                - 1024 /* row key max size */
+                - 64   /* timestamp size */
+                - 64 * 3 /* 3 datetime fields */
+
+                // - 8 * 1024 /* ID */
+                )]
+
+            public string Data { get; set; }
+
+            public DateTime? ExpiryDate { get; set; }
+
+            public DateTime CreatedDate { get; set; }
+
+            public DateTime ModifiedDate { get; set; }
+
+            internal bool HasExpired
+            {
+                get { return ExpiryDate != null && ExpiryDate < DateTime.UtcNow; }
+            }
+
+        }
+
+    }
+}

--- a/src/ServiceStack.Azure.Storage/ServiceStack.Azure.Storage.csproj
+++ b/src/ServiceStack.Azure.Storage/ServiceStack.Azure.Storage.csproj
@@ -104,6 +104,7 @@
     <Compile Include="AzureBlobVirtualFile.cs" />
     <Compile Include="AzureBlobVirtualPathProvider.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="AzureTableCacheClient.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/ServiceStack.Azure.sln
+++ b/src/ServiceStack.Azure.sln
@@ -7,6 +7,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Azure.Storage"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ServiceStack.Azure.Tests", "..\test\ServiceStack.Azure.Tests\ServiceStack.Azure.Tests.csproj", "{6DC5FB0E-DEE0-42BC-9FEE-23DCED1223E4}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3C21FC51-813A-45BE-ABB1-C352C8B35AA0}"
+	ProjectSection(SolutionItems) = preProject
+		..\license.txt = ..\license.txt
+		..\README.md = ..\README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/test/ServiceStack.Azure.Tests/AzureBlobVirtualPathProviderTests.cs
+++ b/test/ServiceStack.Azure.Tests/AzureBlobVirtualPathProviderTests.cs
@@ -37,6 +37,22 @@ namespace ServiceStack.Azure.Tests
             storageAccount.CreateCloudBlobClient().GetContainerReference(ContainerName).DeleteIfExists();
         }
 
+        [Test]
+        public void Can_have_many_items()
+        {
+            var pathProvider = GetPathProvider();
+
+            int count = 200;
+            count.Times(i =>
+            {
+                var filePath = "file-{0}.txt".Fmt(i);
+                pathProvider.WriteFile(filePath, "data");
+            });
+
+            Assert.That(pathProvider.RootDirectory.Files.Count, Is.EqualTo(count));
+
+        }
+
     }
 
 

--- a/test/ServiceStack.Azure.Tests/AzureTableCacheClientTests.cs
+++ b/test/ServiceStack.Azure.Tests/AzureTableCacheClientTests.cs
@@ -1,0 +1,37 @@
+﻿using ServiceStack.Azure.Tests.Shared;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ServiceStack.Caching;
+using ServiceStack.Azure.Storage;
+using NUnit.Framework;
+
+namespace ServiceStack.Azure.Tests
+{
+    public class AzureTableCacheClientTests : CacheClientTestsBase
+    {
+        public override ICacheClient CreateClient()
+        {
+            string connStr = "UseDevelopmentStorage=true;";
+            return new AzureTableCacheClient(connStr);
+        }
+
+        [Test]
+        public void Can_Increment_In_Parallel()
+        {
+            var cache = CreateClient();
+            int count = 10;
+            var fns = count.Times(i => (Action)(() =>
+            {
+                cache.Increment("concurrent-inc-test", 1);
+            }));
+
+            Parallel.Invoke(fns.ToArray());
+
+            var entry = cache.Get<long>("concurrent-inc-test");
+            Assert.That(entry, Is.EqualTo(10));
+        }
+    }
+}

--- a/test/ServiceStack.Azure.Tests/CacheClientTestsBase.cs
+++ b/test/ServiceStack.Azure.Tests/CacheClientTestsBase.cs
@@ -1,0 +1,338 @@
+﻿using System;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using ServiceStack.Auth;
+using ServiceStack.Caching;
+using ServiceStack.Text;
+
+namespace ServiceStack.Azure.Tests.Shared
+{
+    public class Item
+    {
+        public int Id { get; set; }
+
+        public string Name { get; set; }
+
+        protected bool Equals(Item other)
+        {
+            return Id == other.Id && string.Equals(Name, other.Name);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != this.GetType()) return false;
+            return Equals((Item)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Id * 397) ^ (Name != null ? Name.GetHashCode() : 0);
+            }
+        }
+    }
+
+    public class CustomAuthSession : AuthUserSession
+    {
+        [DataMember]
+        public string Custom { get; set; }
+    }
+
+    [TestFixture]
+    public abstract class CacheClientTestsBase
+    {
+        private readonly ICacheClient Cache;
+
+        public abstract ICacheClient CreateClient();
+
+        protected CacheClientTestsBase()
+        {
+            Cache = CreateClient();
+        }
+
+        [TestFixtureTearDown]
+        public void TestFixtureTearDown()
+        {
+            Cache.Dispose();
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            Cache.FlushAll();
+        }
+
+        [Test]
+        public void Does_flush_all()
+        {
+            3.Times(i =>
+                Cache.Set(i.ToUrn<Item>(), new Item { Id = i, Name = "Name" + i }));
+
+            Assert.That(Cache.Get<Item>(1.ToUrn<Item>()), Is.Not.Null);
+
+            Cache.FlushAll();
+
+            Assert.That(Cache.Get<Item>(1.ToUrn<Item>()), Is.Null);
+        }
+
+        [Test]
+        public void Can_set_and_remove_entry()
+        {
+            var key = 1.ToUrn<Item>();
+
+            var item = Cache.Get<Item>(key);
+            Assert.That(item, Is.Null);
+
+            var whenNotExists = Cache.Set(key, new Item { Id = 1, Name = "Foo" });
+            Assert.That(whenNotExists, Is.True);
+            var whenExists = Cache.Set(key, new Item { Id = 1, Name = "Foo" });
+            Assert.That(whenExists, Is.True);
+
+            item = Cache.Get<Item>(key);
+            Assert.That(item, Is.Not.Null);
+            Assert.That(item.Name, Is.EqualTo("Foo"));
+
+            whenExists = Cache.Remove(key);
+            Assert.That(whenExists, Is.True);
+
+            whenNotExists = Cache.Remove(key);
+            Assert.That(whenNotExists, Is.False);
+        }
+
+        [Test]
+        public void Can_update_existing_entry()
+        {
+            var key = 1.ToUrn<Item>();
+
+            Cache.Set(key, new Item { Id = 1, Name = "Foo" });
+            Cache.Set(key, new Item { Id = 2, Name = "Updated" });
+
+            var item = Cache.Get<Item>(key);
+
+            Assert.That(item.Id, Is.EqualTo(2));
+            Assert.That(item.Name, Is.EqualTo("Updated"));
+        }
+
+        [Test]
+        public void Does_SetAll_and_GetAll()
+        {
+            var map = 3.Times(i => new Item { Id = i, Name = "Name" + i })
+                .ToSafeDictionary(x => x.ToUrn());
+
+            Cache.SetAll(map);
+
+            var cacheMap = Cache.GetAll<Item>(map.Keys);
+
+            Assert.That(cacheMap, Is.EquivalentTo(map));
+        }
+
+        [Test]
+        public void Does_not_return_expired_items()
+        {
+            var key = 1.ToUrn<Item>();
+
+            Cache.Set(key, new Item { Id = 1, Name = "Foo" }, DateTime.UtcNow.AddSeconds(-1));
+            Assert.That(Cache.Get<Item>(key), Is.Null);
+
+            Cache.Remove(key);
+
+            Cache.Set(key, new Item { Id = 1, Name = "Foo" }, TimeSpan.FromMilliseconds(100));
+            var entry = Cache.Get<Item>(key);
+            Assert.That(entry, Is.Not.Null);
+            Thread.Sleep(200);
+
+            Assert.That(Cache.Get<Item>(key), Is.Null);
+
+            Cache.Remove(key);
+
+            Cache.Set(key, new Item { Id = 1, Name = "Foo" }, DateTime.UtcNow.AddMilliseconds(200));
+            entry = Cache.Get<Item>(key);
+            Assert.That(entry, Is.Not.Null);
+            Thread.Sleep(300);
+
+            Assert.That(Cache.Get<Item>(key), Is.Null);
+        }
+
+        [Test]
+        public void Can_increment_and_decrement_values()
+        {
+            Assert.That(Cache.Increment("incr:a", 2), Is.EqualTo(2));
+            Assert.That(Cache.Increment("incr:a", 3), Is.EqualTo(5));
+
+            Assert.That(Cache.Decrement("decr:a", 2), Is.EqualTo(-2));
+            Assert.That(Cache.Decrement("decr:a", 3), Is.EqualTo(-5));
+        }
+
+        [Test]
+        public void Can_remove_multiple_items()
+        {
+            var map = 5.Times(i => new Item { Id = i, Name = "Name" + i })
+                .ToSafeDictionary(x => x.ToUrn());
+
+            Cache.SetAll(map);
+
+            Cache.RemoveAll(map.Keys);
+
+            var cacheMap = Cache.GetAll<Item>(map.Keys);
+
+            Assert.That(cacheMap.Count, Is.EqualTo(5));
+            Assert.That(cacheMap.Values.All(x => x == null));
+        }
+
+        [Test]
+        public void Can_retrieve_IAuthSession()
+        {
+            IAuthSession session = new CustomAuthSession
+            {
+                Id = "sess-1",
+                UserAuthId = "1",
+                Custom = "custom"
+            };
+
+            var sessionKey = SessionFeature.GetSessionKey(session.Id);
+            Cache.Set(sessionKey, session, SessionFeature.DefaultSessionExpiry);
+
+            var sessionCache = Cache.Get<IAuthSession>(sessionKey);
+            Assert.That(sessionCache, Is.Not.Null);
+
+            var typedSession = sessionCache as CustomAuthSession;
+            Assert.That(typedSession, Is.Not.Null);
+            Assert.That(typedSession.Custom, Is.EqualTo("custom"));
+        }
+
+        [Test]
+        public void Can_retrieve_TimeToLive_on_IAuthSession()
+        {
+            IAuthSession session = new CustomAuthSession
+            {
+                Id = "sess-1",
+                UserAuthId = "1",
+                Custom = "custom"
+            };
+
+            var sessionKey = SessionFeature.GetSessionKey(session.Id);
+            Cache.Remove(sessionKey);
+
+            var ttl = Cache.GetTimeToLive(sessionKey);
+            Assert.That(ttl, Is.Null);
+
+            Cache.Set(sessionKey, session);
+            ttl = Cache.GetTimeToLive(sessionKey);
+            Assert.That(ttl.Value, Is.EqualTo(TimeSpan.MaxValue));
+
+            var sessionExpiry = SessionFeature.DefaultSessionExpiry;
+            Cache.Set(sessionKey, session, sessionExpiry);
+            ttl = Cache.GetTimeToLive(sessionKey);
+            var roundedToSec = new TimeSpan(ttl.Value.Ticks - (ttl.Value.Ticks % 1000));
+            Assert.That(roundedToSec, Is.GreaterThan(TimeSpan.FromSeconds(0)));
+            Assert.That(roundedToSec, Is.LessThanOrEqualTo(sessionExpiry));
+        }
+
+        [Test]
+        public void Can_retrieve_IAuthSession_with_global_ExcludeTypeInfo_set()
+        {
+            JsConfig.ExcludeTypeInfo = true;
+
+            IAuthSession session = new CustomAuthSession
+            {
+                Id = "sess-1",
+                UserAuthId = "1",
+                Custom = "custom"
+            };
+
+            var sessionKey = SessionFeature.GetSessionKey(session.Id);
+            Cache.Set(sessionKey, session, SessionFeature.DefaultSessionExpiry);
+
+            var sessionCache = Cache.Get<IAuthSession>(sessionKey);
+            Assert.That(sessionCache, Is.Not.Null);
+
+            var typedSession = sessionCache as CustomAuthSession;
+            Assert.That(typedSession, Is.Not.Null);
+            Assert.That(typedSession.Custom, Is.EqualTo("custom"));
+
+            JsConfig.Reset();
+        }
+
+        [Test]
+        public void Can_cache_multiple_items_in_parallel()
+        {
+            var cache = CreateClient();
+            var fns = 10.Times(i => (Action)(() =>
+            {
+                cache.Set("concurrent-test", "Data: {0}".Fmt(i));
+            }));
+
+            Parallel.Invoke(fns.ToArray());
+
+            var entry = cache.Get<string>("concurrent-test");
+            Assert.That(entry, Is.StringStarting("Data: "));
+        }
+
+        [Test]
+        public void Can_set_get_and_remove_ISession()
+        {
+            var sessionA = new SessionFactory(CreateClient()).CreateSession("a");
+            var sessionB = new SessionFactory(CreateClient()).CreateSession("b");
+
+            3.Times(i =>
+            {
+                sessionA.Set("key" + i, "value" + i);
+                sessionB.Set("key" + i, "value" + i);
+            });
+
+            var value1 = sessionA.Get<String>("key1");
+            Assert.That(value1, Is.EqualTo("value1"));
+
+            sessionA.RemoveAll();
+            value1 = sessionA.Get<String>("key1");
+            Assert.That(value1, Is.Null);
+
+            value1 = sessionB.Get<String>("key1");
+            Assert.That(value1, Is.EqualTo("value1"));
+        }
+
+        [Test]
+        public void Can_GetKeysByPattern()
+        {
+            if (!(Cache is ICacheClientExtended))
+                return;
+
+            JsConfig.ExcludeTypeInfo = true;
+
+            5.Times(i =>
+            {
+                IAuthSession session = new CustomAuthSession
+                {
+                    Id = "sess-" + i,
+                    UserAuthId = i.ToString(),
+                    Custom = "custom" + i
+                };
+
+                var sessionKey = SessionFeature.GetSessionKey(session.Id);
+                Cache.Set(sessionKey, session, SessionFeature.DefaultSessionExpiry);
+                Cache.Set("otherkey" + i, i);
+            });
+
+            var sessionPattern = IdUtils.CreateUrn<IAuthSession>("");
+            Assert.That(sessionPattern, Is.EqualTo("urn:iauthsession:"));
+            var sessionKeys = Cache.GetKeysStartingWith(sessionPattern).ToList();
+
+            Assert.That(sessionKeys.Count, Is.EqualTo(5));
+            Assert.That(sessionKeys.All(x => x.StartsWith("urn:iauthsession:")));
+
+            var allSessions = Cache.GetAll<IAuthSession>(sessionKeys);
+            Assert.That(allSessions.Values.Count(x => x != null), Is.EqualTo(sessionKeys.Count));
+
+            var allKeys = Cache.GetAllKeys().ToList();
+            Assert.That(allKeys.Count, Is.EqualTo(10));
+
+            JsConfig.Reset();
+        }
+    }
+}

--- a/test/ServiceStack.Azure.Tests/ServiceStack.Azure.Tests.csproj
+++ b/test/ServiceStack.Azure.Tests/ServiceStack.Azure.Tests.csproj
@@ -39,16 +39,16 @@
       <HintPath>..\..\src\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    <Reference Include="Microsoft.Data.Edm, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\Microsoft.Data.Edm.5.7.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    <Reference Include="Microsoft.Data.OData, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\Microsoft.Data.OData.5.7.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\Microsoft.Data.Services.Client.5.7.0\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -99,8 +99,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\src\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+    <Reference Include="System.Spatial, Version=5.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\System.Spatial.5.7.0\lib\net40\System.Spatial.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />
@@ -119,6 +119,8 @@
   </Choose>
   <ItemGroup>
     <Compile Include="AzureBlobVirtualPathProviderTests.cs" />
+    <Compile Include="AzureTableCacheClientTests.cs" />
+    <Compile Include="CacheClientTestsBase.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ServiceStack.Azure.Tests/app.config
+++ b/test/ServiceStack.Azure.Tests/app.config
@@ -14,6 +14,10 @@
         <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Services.Client" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.7.0.0" newVersion="5.7.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/ServiceStack.Azure.Tests/packages.config
+++ b/test/ServiceStack.Azure.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net452" />
-  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net452" />
+  <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net452" />
+  <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net452" />
+  <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="NUnit" version="2.6.4" targetFramework="net452" />
   <package id="ServiceStack" version="4.0.48" targetFramework="net452" />
@@ -14,6 +14,6 @@
   <package id="ServiceStack.Redis" version="4.0.48" targetFramework="net452" />
   <package id="ServiceStack.Server" version="4.0.48" targetFramework="net452" />
   <package id="ServiceStack.Text" version="4.0.48" targetFramework="net452" />
-  <package id="System.Spatial" version="5.6.4" targetFramework="net452" />
+  <package id="System.Spatial" version="5.7.0" targetFramework="net452" />
   <package id="WindowsAzure.Storage" version="6.1.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Initial support for AzureTableCacheClient.  Some issues with concurrent operations, such as `Increment`, which are called out in a failing unit test.

Is it assumed that Increment/Decrement are atomic operations on all cache clients?  I don't recall seeing that spelled out explicitly.
