### PR TITLE
Allow container customization before it's created

### DIFF
--- a/src/ServiceStack.Azure.Storage/AzureBlobVirtualDirectory.cs
+++ b/src/ServiceStack.Azure.Storage/AzureBlobVirtualDirectory.cs
@@ -58,9 +58,9 @@ namespace ServiceStack.Azure.Storage
         // Azure Blob storage directories only exist if there are contents beneath them
         public bool Exists()
         {
-            var ret = pathProvider.Container.ListBlobs(this.DirPath, false)
-                .Where(q => q.GetType() == typeof(CloudBlobDirectory))
-                .Any();
+            var ret = pathProvider.Container
+                .ListBlobs(this.DirPath, false)
+                .Any(q => q is CloudBlobDirectory);
             return ret;
 
         }
@@ -91,16 +91,13 @@ namespace ServiceStack.Azure.Storage
             var dir = (this.DirPath == null) ? null : this.DirPath + pathProvider.RealPathSeparator;
 
             var ret = pathProvider.Container.ListBlobs(dir)
-                      .Where(q => q.GetType() == typeof(CloudBlockBlob))
+                      .Where(q => q is CloudBlockBlob)
                       .Where(q =>
                       {
                           var x = ((CloudBlockBlob)q).Name.Glob(globPattern);
                           return x;
                       })
-                      .Select(q =>
-                      {
-                          return new AzureBlobVirtualFile(pathProvider, this).Init(q as CloudBlockBlob);
-                      });
+                      .Select(q => new AzureBlobVirtualFile(pathProvider, this).Init(q as CloudBlockBlob));
             return ret;
         }
 

--- a/src/ServiceStack.Azure.Storage/AzureBlobVirtualPathProvider.cs
+++ b/src/ServiceStack.Azure.Storage/AzureBlobVirtualPathProvider.cs
@@ -42,12 +42,15 @@ namespace ServiceStack.Azure.Storage
         }
 
 
-        public AzureBlobVirtualPathProvider(CloudStorageAccount storageAccount, string containerName, IAppHost appHost)
+        public AzureBlobVirtualPathProvider(CloudStorageAccount storageAccount, string containerName, IAppHost appHost, 
+            Action<CloudStorageAccount, CloudBlobClient, CloudBlobContainer> beforeCreate = null)
             : base(appHost)
         {
             this.StorageAccount = storageAccount;
             this.client = storageAccount.CreateCloudBlobClient();
             this.Container = client.GetContainerReference(containerName);
+            if (beforeCreate != null)
+                beforeCreate(storageAccount, client, Container);
             this.Container.CreateIfNotExists();
 
             this.rootDirectory = new AzureBlobVirtualDirectory(this, null);

--- a/src/ServiceStack.Azure.Storage/AzureBlobVirtualPathProvider.cs
+++ b/src/ServiceStack.Azure.Storage/AzureBlobVirtualPathProvider.cs
@@ -100,10 +100,11 @@ namespace ServiceStack.Azure.Storage
         public override IVirtualFile GetFile(string virtualPath)
         {
             var filePath = SanitizePath(virtualPath);
-
+            if (virtualPath.IsNullOrEmpty())
+                return null;
             CloudBlockBlob blob = Container.GetBlockBlobReference(filePath);
-            if (!blob.Exists()) return null;
-
+            if (!blob.Exists())
+                return null;
             return new AzureBlobVirtualFile(this, GetDirectory(GetDirPath(virtualPath))).Init(blob);
         }
 
@@ -134,7 +135,7 @@ namespace ServiceStack.Azure.Storage
             var dir = new AzureBlobVirtualDirectory(this, fromDirPath);
 
             return Container.ListBlobs((fromDirPath == null) ? null : fromDirPath + this.RealPathSeparator)
-                .Where(q => q.GetType() == typeof(CloudBlockBlob))
+                .Where(q => q is CloudBlockBlob)
                 .Select(q => new AzureBlobVirtualFile(this, dir).Init(q as CloudBlockBlob));
 
         }


### PR DESCRIPTION
introduced `beforeCreate` callback, which allows for customization of container creation parameters. 
Example use case - to allow public access of Blobs

`new AzureBlobVirtualPathProvider(storageAccount, "websitecontent", appHost,
                (account, client, blobContainer) => blobContainer.CreateIfNotExists(BlobContainerPublicAccessType.Blob));`

includes also a little bit of code cleanup
