### PR TITLE
Fix mismatch between Client and Server queue names

### DIFF
--- a/src/ServiceStack.Azure/Messaging/ServiceBusMqMessageFactory.cs
+++ b/src/ServiceStack.Azure/Messaging/ServiceBusMqMessageFactory.cs
@@ -120,9 +120,6 @@ namespace ServiceStack.Azure.Messaging
 
         protected internal QueueClient GetOrCreateClient(string queueName)
         {
-            if (queueName.StartsWith(QueueNames.MqPrefix))
-                queueName = queueName.ReplaceFirst(QueueNames.MqPrefix, "");
-
             if (sbClients.ContainsKey(queueName))
                 return sbClients[queueName];
 

--- a/src/ServiceStack.Azure/Messaging/ServiceBusMqMessageProducer.cs
+++ b/src/ServiceStack.Azure/Messaging/ServiceBusMqMessageProducer.cs
@@ -75,9 +75,6 @@ namespace ServiceStack.Azure.Messaging
 #if NETSTANDARD2_0
         protected MessageReceiver GetOrCreateMessageReceiver(string queueName)
         {
-            if (queueName.StartsWith(QueueNames.MqPrefix))
-                queueName = queueName.ReplaceFirst(QueueNames.MqPrefix, "");
-
             if (sbReceivers.ContainsKey(queueName))
                 return sbReceivers[queueName];
 

--- a/tests/ServiceStack.Azure.Tests/Messaging/MqServerAppHostTests.cs
+++ b/tests/ServiceStack.Azure.Tests/Messaging/MqServerAppHostTests.cs
@@ -203,6 +203,8 @@ namespace ServiceStack.Azure.Tests.Messaging
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
+            QueueNames.MqPrefix = "mq."; // mq: is not valid in Azure Service Bus Queue Names
+
             appHost = new MqTestsAppHost(() => CreateMqServer())
                 .Init()
                 .Start(ListeningOn);
@@ -363,7 +365,7 @@ namespace ServiceStack.Azure.Tests.Messaging
                 {
                     var requestMsg = new Message<ValidateTestMq>(request)
                     {
-                        ReplyTo = "mq:{0}.replyto".Fmt(request.GetType().Name)
+                        ReplyTo = "{0}{1}.replyto".Fmt(QueueNames.MqPrefix, request.GetType().Name)
                     };
                     mqProducer.Publish(requestMsg);
 
@@ -375,7 +377,7 @@ namespace ServiceStack.Azure.Tests.Messaging
                     request = new ValidateTestMq { Id = 10 };
                     requestMsg = new Message<ValidateTestMq>(request)
                     {
-                        ReplyTo = "mq:{0}.replyto".Fmt(request.GetType().Name)
+                        ReplyTo = "{0}{1}.replyto".Fmt(QueueNames.MqPrefix, request.GetType().Name)
                     };
                     mqProducer.Publish(requestMsg);
                     var responseMsg = mqClient.Get<ValidateTestMqResponse>(requestMsg.ReplyTo, null);
@@ -397,7 +399,7 @@ namespace ServiceStack.Azure.Tests.Messaging
                 {
                     var requestMsg = new Message<ThrowGenericError>(request)
                     {
-                        ReplyTo = "mq:{0}.replyto".Fmt(request.GetType().Name)
+                        ReplyTo = "{0}{1}.replyto".Fmt(QueueNames.MqPrefix, request.GetType().Name)
                     };
                     mqProducer.Publish(requestMsg);
 


### PR DESCRIPTION
The client is removing the MQ prefix from the QueueName before creating the connection.
The server doesn't do this, therefore they are listening and sending to different queues.

If no prefix is wanted this can be configured by setting QueueNames.MqPrefix to an empty string.
Therefore I see no reason to always remove the MqPrefix.