### PR TITLE
Use new Azure ServiceBus library that can create queues

### DIFF
--- a/NuGet/ServiceStack.Azure.Core/servicestack.azure.core.nuspec
+++ b/NuGet/ServiceStack.Azure.Core/servicestack.azure.core.nuspec
@@ -4,7 +4,7 @@
     <id>ServiceStack.Azure.Core</id>
     <title>ServiceStack.Azure .NET Standard 2.0</title>
     <version>5.0.0</version>
-    <authors>ServiceStack</authors> 
+    <authors>ServiceStack</authors>
     <owners>ServiceStack</owners>
     <description>
       .NET Standard 2.0 version of ServiceStack.Azure
@@ -13,12 +13,11 @@
     <licenseUrl>https://servicestack.net/terms</licenseUrl>
     <iconUrl>https://servicestack.net/img/logo-32.png</iconUrl>
     <tags>ServiceStack Azure WebServices ServiceBus Cache CacheClient</tags>
-    <language>en-US</language> 
+    <language>en-US</language>
     <copyright>ServiceStack and contributors</copyright>
       <dependencies>
           <group targetFramework=".netstandard2.0">
-              <dependency id="Microsoft.Azure.ServiceBus" version="[2.0.0, )" />
-              <dependency id="Microsoft.Azure.Management.ServiceBus" version="[1.2.0, )" />
+              <dependency id="Microsoft.Azure.ServiceBus" version="[3.1.0-preview, )" />
               <dependency id="WindowsAzure.Storage" version="[9.1.1, )" />
               <dependency id="ServiceStack.Core" version="5.0.0" />
           </group>

--- a/src/ServiceStack.Azure/Messaging/QueueClientExtensions.cs
+++ b/src/ServiceStack.Azure/Messaging/QueueClientExtensions.cs
@@ -1,11 +1,9 @@
 using System.Threading.Tasks;
 using System;
 using System.Text;
-using ServiceStack.Text;
 
 namespace ServiceStack.Azure.Messaging
 {
-
     public static class QueueClientExtensions
     {
 #if NETSTANDARD2_0
@@ -26,11 +24,11 @@ namespace ServiceStack.Azure.Messaging
         public static string GetBodyString(this Microsoft.Azure.ServiceBus.Message message)
         {
             var strMessage = Encoding.UTF8.GetString(message.Body);
-            
+
             //Windows Azure Client is not wire-compatible with .NET Core client
-            //we check if the message comes from Windows client and cut off 
+            //we check if the message comes from Windows client and cut off
             //64 header chars and 2 footer chars
-            //see https://github.com/Azure/azure-service-bus-dotnet/issues/239  
+            //see https://github.com/Azure/azure-service-bus-dotnet/issues/239
             if (strMessage.StartsWith("@\u0006string", StringComparison.Ordinal))
             {
                 strMessage = strMessage.Substring(64, strMessage.Length - 66);
@@ -43,5 +41,5 @@ namespace ServiceStack.Azure.Messaging
         internal static string SafeQueueName(this string queueName) =>
             queueName?.Replace(":", ".");
     }
-    
+
 }

--- a/src/ServiceStack.Azure/Messaging/ServiceBusMqClient.cs
+++ b/src/ServiceStack.Azure/Messaging/ServiceBusMqClient.cs
@@ -2,8 +2,6 @@
 using ServiceStack.Text;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 #if NETSTANDARD2_0
 using Microsoft.Azure.ServiceBus;
@@ -138,7 +136,7 @@ namespace ServiceStack.Azure.Messaging
 
                 if (!task.IsCompleted)
                     throw new TimeoutException("Reached timeout while getting message from client");
-            } else 
+            } else
             {
                 await task;
             }
@@ -170,7 +168,7 @@ namespace ServiceStack.Azure.Messaging
         {
             if (parentFactory.MqServer.DisableNotifyMessages)
                 return;
-            
+
             Publish(queueName, message);
         }
 

--- a/src/ServiceStack.Azure/Messaging/ServiceBusMqMessageProducer.cs
+++ b/src/ServiceStack.Azure/Messaging/ServiceBusMqMessageProducer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using ServiceStack.Messaging;
 using ServiceStack.Text;
 #if NETSTANDARD2_0
@@ -56,6 +55,7 @@ namespace ServiceStack.Azure.Messaging
             message.ReplyTo = message.ReplyTo.SafeQueueName();
 
             var sbClient = parentFactory.GetOrCreateClient(queueName);
+            parentFactory.RegisterQueueByName(queueName);
             using (JsConfig.With(includeTypeInfo: true))
             {
                 var msgBody = JsonSerializer.SerializeToString(message, typeof(IMessage));
@@ -86,7 +86,7 @@ namespace ServiceStack.Azure.Messaging
              parentFactory.address,
              queueName,
              ReceiveMode.ReceiveAndDelete);  //should be ReceiveMode.PeekLock, but it does not delete messages from queue on CompleteAsync()
-             
+
             sbReceivers.Add(queueName, messageReceiver);
             return messageReceiver;
         }

--- a/src/ServiceStack.Azure/Messaging/ServiceBusMqServer.cs
+++ b/src/ServiceStack.Azure/Messaging/ServiceBusMqServer.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ServiceStack.Azure.Messaging
 {
@@ -51,7 +49,7 @@ namespace ServiceStack.Azure.Messaging
         public List<Type> RegisteredTypes => handlerMap.Keys.ToList();
 
         /// <summary>
-        /// Opt-in to only publish responses on this white list. 
+        /// Opt-in to only publish responses on this white list.
         /// Publishes all responses by default.
         /// </summary>
         public string[] PublishResponsesWhitelist { get; set; }
@@ -60,7 +58,7 @@ namespace ServiceStack.Azure.Messaging
         {
             set => PublishResponsesWhitelist = value ? TypeConstants.EmptyStringArray : null;
         }
-        
+
         /// <summary>
         /// Disable publishing .outq Messages for Responses with no return type
         /// </summary>

--- a/src/ServiceStack.Azure/Messaging/ServiceBusMqWorker.cs
+++ b/src/ServiceStack.Azure/Messaging/ServiceBusMqWorker.cs
@@ -3,8 +3,6 @@ using ServiceStack.Messaging;
 using ServiceStack.Text;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 #if NETSTANDARD2_0

--- a/src/ServiceStack.Azure/ServiceStack.Azure.csproj
+++ b/src/ServiceStack.Azure/ServiceStack.Azure.csproj
@@ -46,8 +46,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0-preview" />
 
     <Reference Include="..\..\lib\netstandard2.0\ServiceStack.Interfaces.dll" />
     <Reference Include="..\..\lib\netstandard2.0\ServiceStack.Text.dll" />

--- a/tests/ServiceStack.Azure.Tests/ServiceStack.Azure.Tests.csproj
+++ b/tests/ServiceStack.Azure.Tests/ServiceStack.Azure.Tests.csproj
@@ -27,7 +27,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="WindowsAzure.ServiceBus" Version="4.1.8" />
     <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.2.3" />
 
     <Reference Include="..\..\lib\net45\ServiceStack.Interfaces.dll" />
@@ -55,7 +54,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.1.0-preview" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.1" />


### PR DESCRIPTION
* Updated servicestack.azure.core.nuspec to use Microsoft.Azure.ServiceBus and dropped icrosoft.Azure.Management.ServiceBus
* Added a prefetch property to ServiceBusMqMessageFactory (removed, there is a separate PR for this)
* Added ctor to ServiceBusMqServer that accepts ServiceBusMqMessageFactory which allows prefetch to be configured
* Microsoft.Azure.ServiceBus library now includes management api that allows queues to be created from a connectionstring

All MQ tests run and pass (except for ignored test)