### PR TITLE
Fix Azure Service Bus BadRequest due to invalid [] chars

### DIFF
--- a/src/ServiceStack.Azure/Messaging/QueueClientExtensions.cs
+++ b/src/ServiceStack.Azure/Messaging/QueueClientExtensions.cs
@@ -54,7 +54,7 @@ namespace ServiceStack.Azure.Messaging
         }
 
         internal static string SafeQueueName(this string queueName) =>
-            queueName?.Replace(":", ".");
+            queueName?.Replace(":", ".").Replace("[]", "Array");
     }
     
 }


### PR DESCRIPTION
When creating a queue name for batch requests (such as CreateContact[]) the "[" and "]" chars will cause a validation failure so replace "[]" with "Array"