### PR TITLE
Feature/last modified date

### DIFF
--- a/src/ServiceStack.Azure/Storage/AzureBlobVirtualDirectory.cs
+++ b/src/ServiceStack.Azure/Storage/AzureBlobVirtualDirectory.cs
@@ -50,7 +50,17 @@ namespace ServiceStack.Azure.Storage
 
         // Azure CloudBlobDirectories can only exist if there is a file within that folder
         // therefore we can use the last modified date of the files to determine the last modified date
-        public override DateTime LastModified => Files?.Max(f => f.LastModified) ?? DateTime.MinValue;
+        // Where the CloudBlobDirectory is nested without a file return DateTime.MinValue
+        public override DateTime LastModified
+        {
+            get
+            {
+                if (Files != null && Files.Any())
+                    return Files?.Max(f => f.LastModified) ?? DateTime.MinValue;
+                else
+                    return DateTime.MinValue;
+            }
+        }
 
         public override IEnumerable<IVirtualFile> Files => PathProvider.GetImmediateFiles(this.DirPath);
 

--- a/src/ServiceStack.Azure/Storage/AzureBlobVirtualDirectory.cs
+++ b/src/ServiceStack.Azure/Storage/AzureBlobVirtualDirectory.cs
@@ -50,17 +50,7 @@ namespace ServiceStack.Azure.Storage
 
         // Azure CloudBlobDirectories can only exist if there is a file within that folder
         // therefore we can use the last modified date of the files to determine the last modified date
-        // Where the CloudBlobDirectory is nested without a file return DateTime.MinValue
-        public override DateTime LastModified
-        {
-            get
-            {
-                if (Files != null && Files.Any())
-                    return Files?.Max(f => f.LastModified) ?? DateTime.MinValue;
-                else
-                    return DateTime.MinValue;
-            }
-        }
+        public override DateTime LastModified => (Files != null && Files.Any()) ? Files.Max(f => f.LastModified) : DateTime.MinValue;
 
         public override IEnumerable<IVirtualFile> Files => PathProvider.GetImmediateFiles(this.DirPath);
 


### PR DESCRIPTION
When there are nested folders without any files within them (/root/level1/level2/file.txt) then return the last modified date as DateTime.MinValue

So the check is based off 
1. The Files property is not null
1. There are Files
1. Get the Max Last Modified date as the last modified date for the folder
1. DateTime.MinValue where 1 and 2 is false