### PR TITLE
Update Microsoft.ServiceStack.Azure to 5.1.0 to fix .net 5 bug

### DIFF
--- a/src/ServiceStack.Azure/ServiceStack.Azure.Core.csproj
+++ b/src/ServiceStack.Azure/ServiceStack.Azure.Core.csproj
@@ -20,7 +20,7 @@
 
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.0" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
   </ItemGroup>
 

--- a/src/ServiceStack.Azure/ServiceStack.Azure.Source.csproj
+++ b/src/ServiceStack.Azure/ServiceStack.Azure.Source.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.1.3" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.0" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
   </ItemGroup>
 

--- a/src/ServiceStack.Azure/ServiceStack.Azure.csproj
+++ b/src/ServiceStack.Azure/ServiceStack.Azure.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="4.2.0" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.0" />
     <PackageReference Include="Microsoft.Azure.Management.ServiceBus" Version="2.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR fixes a .NET 5 bug: https://github.com/Azure/azure-sdk-for-net/issues/13899

Currently you get "Operation is not valid due to the current state of the object." exception.