### PR TITLE
Fix Deadlock

### DIFF
--- a/src/ServiceStack.Azure/Messaging/ServiceBusMqClient.cs
+++ b/src/ServiceStack.Azure/Messaging/ServiceBusMqClient.cs
@@ -86,7 +86,7 @@ namespace ServiceStack.Azure.Messaging
             string lockToken = null;
 
 #if NETSTANDARD2_0
-            var msg = sbClient.ReceiveAsync(timeout).Result;
+            var msg = Task.Run(() => sbClient.ReceiveAsync(timeout)).GetAwaiter().GetResult();
             if (msg != null)
              lockToken = msg.SystemProperties.LockToken;
 #else


### PR DESCRIPTION
Currently 
`sbClient.ReceiveAsync(timeout).Result;`
causes a deadlock (not always, but sometimes).

`bClient.ReceiveAsync(timeout).GetAwaiter().GetResult()` 
also deadlocks

The change forces the execution onto another thread and avoids the deadlock completely.

